### PR TITLE
Update and rename connectors.yml.example to connectors.yml

### DIFF
--- a/config/connectors.yml
+++ b/config/connectors.yml
@@ -6,7 +6,7 @@ revision: main
 elasticsearch:
   cloud_id: https://jazz-demo.ent.us-central1.gcp.cloud.es.io
   hosts: http://stahing.jazz.com.pk
-  api_key: search-1ihq6xh6pujo4xa8wktoni9x
+  api_key: dXJyU2FvTUJpTVpSVVJHTlR2MnY6SFlqeVpVWnJUQS1xbEdjX2lHQ1NaUQ==
   retry_on_failure: 3
   request_timeout: 120
   disable_warnings: true
@@ -27,5 +27,5 @@ heartbeat_interval: 1800
 
 native_mode: true
 connector_id: connector_id: "WLrGaoMBiMZRURGNMv3T"        
-service_type: CHANGEME
+service_type: Full
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-ruby/issues/###


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] [Manual test steps](https://github.com/elastic/connectors-ruby/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
